### PR TITLE
:herb: Specify full endpoint example

### DIFF
--- a/fern/api/definition/lcf.yml
+++ b/fern/api/definition/lcf.yml
@@ -12,6 +12,10 @@ service:
       response: LeastCostFulfillment
       errors:
         - NotAuthorized
+      examples: 
+        - request: $CreateLcfRequest.Example1
+          response: 
+            body: $LeastCostFulfillment.Example1
 
 types:
   CreateLcfRequest:
@@ -128,6 +132,15 @@ types:
           First comment includes the carrier, service code, account, cost, and package
       service: Service
       parcel: Parcel
+    examples: 
+      - name: Example1
+        value: 
+          orderId: "shopify_12345"
+          shipTo: $ShipTo.WhiteHouse
+          tags: []
+          comments: []
+          service: $Service.Example1
+          parcel: $Parcel.TestParcel
 
   Service:
     properties:
@@ -148,7 +161,16 @@ types:
         docs: You carrier account that will be used to ship the package.
       cost:
         type: double
-        docs: The cost of the shipping label String reccomends. 
+        docs: The cost of the shipping label String recommends. 
+    examples: 
+      - name: Example1
+        value: 
+          carrier: "carrier"
+          service: "service"
+          deliveryDate: "2017-07-21"
+          saturdayDelivery: false
+          accountNumber: "acc_1234"
+          cost: 2.00
   
   Parcel:
     properties:


### PR DESCRIPTION
@Tyler-O-Douglas I've setup your definition with a full endpoint example and registered your docs -- you can see them coming through now: https://string.docs.buildwithfern.com/api-reference/lcf/create-least-cost-fulfillment.