### PR TITLE
🌿 Configure endpoint display name + secondary style buttons

### DIFF
--- a/fern/api/definition/__package__.yml
+++ b/fern/api/definition/__package__.yml
@@ -5,6 +5,7 @@ service:
   base-path: ""
   endpoints:
     CreateLeastCostFulfillment:
+      display-name: Least Cost Fulfillment
       docs: For a shipment, find the lowest cost and fasest shipping option based on provided parameters.
       method: POST
       path: /lcf

--- a/fern/api/docs/docs.yml
+++ b/fern/api/docs/docs.yml
@@ -12,15 +12,15 @@ logo:
   href: https://www.meetstring.com/
 favicon: ./favicon.ico
 navbar-links:
-  - type: primary
+  - type: secondary
     text: Manage Your Account
     url: https://billing.stripe.com/p/login/3cscNabV64828N2288
-  - type: primary
-    text: Sign-up!
-    url: https://www.meetstring.com/#pricing
-  - type: primary
+  - type: secondary
     text: Learn More
     url: https://www.meetstring.com/
-  - type: primary
+  - type: secondary
     text: Get Help
     url: mailto:tyler@meetstring.com?subject=String%20API%20Help
+  - type: primary
+    text: Sign Up
+    url: https://www.meetstring.com/#pricing


### PR DESCRIPTION
This PR
- moves the single endpoint from `lcf` to `__package__.yml`. Fern users that have a single endpoint will typically define the endpoint in a `__package__.yml` because the endpoint will show up at the root level (instead of nested within a folder). 
- adds secondary-styled buttons with one call-to-action. 