### PR TITLE
:herb: Set auth to `basic`

### DIFF
--- a/fern/api/definition/api.yml
+++ b/fern/api/definition/api.yml
@@ -1,9 +1,5 @@
 name: api
-auth: MyAuthScheme
-auth-schemes:
-  MyAuthScheme:
-    header: Authorization
-    type: basic
+auth: basic
 error-discrimination:
   strategy: status-code
 environments:


### PR DESCRIPTION
Currently the docs show `Authorization: <MyAuthScheme>` as the example. By making `auth: basic` it will show a username and a password which is more representative for users.